### PR TITLE
Refactor packet_type and seq_flags assignments

### DIFF
--- a/src/puslib/packet.py
+++ b/src/puslib/packet.py
@@ -156,10 +156,10 @@ class CcsdsSpacePacket:
                 raise CrcException
 
         packet_version_number = (packet_id >> 13) & 0b111
-        packet_type = PacketType.TC if (packet_id >> 12) & 0b1 == 1 else PacketType.TM
+        packet_type = PacketType((packet_id >> 12) & 0b1)
         secondary_header_flag = True if (packet_id >> 11) & 0b1 == 1 else False
         apid = packet_id & 0x7ff
-        seq_flags = (seq_ctrl >> 14) & 0b11
+        seq_flags = SequenceFlag((seq_ctrl >> 14) & 0b11)
         seq_count_or_name = seq_ctrl & 0x3fff  # count or name
         return packet_version_number, packet_type, secondary_header_flag, apid, seq_flags, seq_count_or_name, data_length
 


### PR DESCRIPTION
I encountered some inconsistencies when constructing a packet. The `packet_type` property correctly assigns a `PacketType(IntEnum)` object, while the `seq_flags` is a raw `int`, which doesn't match the definition of `_PacketPrimaryHeader`, where the `seq_flags` is a `SequenceFlag(IntEnum)` object. 

This simple change casts to the right data type. Also, it removes one code-branch (if/else) in the assignment of `packet_type`.